### PR TITLE
Update QA domain

### DIFF
--- a/.github/workflows/terraform_provider.yml
+++ b/.github/workflows/terraform_provider.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_QA }}
           REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_QA }}
-          REDISCLOUD_URL: https://qa-api.redislabs.com/v1/
+          REDISCLOUD_URL: https://api.qa.redislabs.com/v1/
           AWS_TEST_CLOUD_ACCOUNT_NAME: oc
 #          REDISCLOUD_ACCESS_KEY: ${{ secrets.REDISCLOUD_ACCESS_KEY_PROD }}
 #          REDISCLOUD_SECRET_KEY: ${{ secrets.REDISCLOUD_SECRET_KEY_PROD }}


### PR DESCRIPTION
In this PR, we've updated the domain to the QA server.

```
from: qa-api.redislabs.com
to:   api.qa.redislabs.com
```